### PR TITLE
refactor: PlaceholderFile own user data

### DIFF
--- a/examples/sftp/src/main.rs
+++ b/examples/sftp/src/main.rs
@@ -328,7 +328,7 @@ impl SyncFilter for Filter {
 
         let dirs = self.sftp.readdir(parent).unwrap();
         let placeholders = dirs
-            .iter()
+            .into_iter()
             .filter(|(path, _)| !Path::new(&client_path).join(path).exists())
             .map(|(path, stat)| {
                 println!("path: {:?}, stat {:?}", path, stat);
@@ -350,11 +350,11 @@ impl SyncFilter for Filter {
                     )
                     .overwrite()
                     // .mark_sync() // need this?
-                    .blob(path.as_os_str().as_encoded_bytes())
+                    .blob(path.into_os_string().into_encoded_bytes())
             })
             .collect::<Vec<_>>();
 
-        ticket.pass_with_placeholder(&placeholders).unwrap();
+        ticket.pass_with_placeholder(placeholders).unwrap();
     }
 
     fn closed(&self, request: Request, info: info::Closed) {

--- a/src/command/commands.rs
+++ b/src/command/commands.rs
@@ -149,14 +149,14 @@ impl Command for Update<'_> {
 
 /// Create placeholder files/directories.
 #[derive(Debug)]
-pub struct CreatePlaceholders {
+pub struct CreatePlaceholders<'a> {
     /// The placeholders to create.
-    pub placeholders: Vec<PlaceholderFile>,
+    pub placeholders: &'a mut [PlaceholderFile],
     /// The total amount of placeholders that are a child of the current directory.
     pub total: u64,
 }
 
-impl Command for CreatePlaceholders {
+impl Command for CreatePlaceholders<'_> {
     const OPERATION: CF_OPERATION_TYPE = CloudFilters::CF_OPERATION_TYPE_TRANSFER_PLACEHOLDERS;
 
     type Result = Vec<core::Result<Usn>>;
@@ -203,7 +203,7 @@ impl Command for CreatePlaceholders {
     }
 }
 
-impl Fallible for CreatePlaceholders {
+impl Fallible for CreatePlaceholders<'_> {
     fn fail(
         connection_key: RawConnectionKey,
         transfer_key: RawTransferKey,

--- a/src/command/commands.rs
+++ b/src/command/commands.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// Read data from a placeholder file.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Read<'a> {
     /// The buffer of data to read into.
     pub buffer: &'a mut [u8],
@@ -54,7 +54,7 @@ impl Command for Read<'_> {
 }
 
 /// Write data to a placeholder file.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub struct Write<'a> {
     /// The buffer of data to write into the file.
     pub buffer: &'a [u8],
@@ -109,7 +109,7 @@ impl Fallible for Write<'_> {
 }
 
 /// Update various properties on a placeholder.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub struct Update<'a> {
     /// Whether or not to mark the placeholder as "synced."
     pub mark_sync: bool,
@@ -148,7 +148,7 @@ impl Command for Update<'_> {
 }
 
 /// Create placeholder files/directories.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub struct CreatePlaceholders {
     /// The placeholders to create.
     pub placeholders: Vec<PlaceholderFile>,
@@ -228,7 +228,7 @@ impl Fallible for CreatePlaceholders {
 }
 
 /// Validate the data range in the placeholder file is valid.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub struct Validate {
     /// The range of data to validate as "good."
     pub range: Range<u64>,
@@ -276,7 +276,7 @@ impl Fallible for Validate {
 }
 
 /// Confirm dehydration of the placeholder file and optionally update its blob.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub struct Dehydrate<'a> {
     /// Optional file blob to update.
     pub blob: Option<&'a [u8]>,
@@ -326,7 +326,7 @@ impl Fallible for Dehydrate<'_> {
 }
 
 /// Confirm deletion of the placeholder.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub struct Delete;
 
 impl Command for Delete {
@@ -367,7 +367,7 @@ impl Fallible for Delete {
 }
 
 /// Confirm rename/move of the placeholder.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub struct Rename;
 
 impl Command for Rename {

--- a/src/command/commands.rs
+++ b/src/command/commands.rs
@@ -149,14 +149,14 @@ impl Command for Update<'_> {
 
 /// Create placeholder files/directories.
 #[derive(Debug, Clone, Default)]
-pub struct CreatePlaceholders<'a> {
+pub struct CreatePlaceholders {
     /// The placeholders to create.
-    pub placeholders: &'a [PlaceholderFile<'a>], // FIXME: placeholder should be mutable
+    pub placeholders: Vec<PlaceholderFile>, // FIXME: placeholder should be mutable
     /// The total amount of placeholders that are a child of the current directory.
     pub total: u64,
 }
 
-impl Command for CreatePlaceholders<'_> {
+impl Command for CreatePlaceholders {
     const OPERATION: CF_OPERATION_TYPE = CloudFilters::CF_OPERATION_TYPE_TRANSFER_PLACEHOLDERS;
 
     type Result = Vec<core::Result<Usn>>;
@@ -203,7 +203,7 @@ impl Command for CreatePlaceholders<'_> {
     }
 }
 
-impl<'a> Fallible for CreatePlaceholders<'a> {
+impl<'a> Fallible for CreatePlaceholders {
     fn fail(
         connection_key: RawConnectionKey,
         transfer_key: RawTransferKey,

--- a/src/command/commands.rs
+++ b/src/command/commands.rs
@@ -151,7 +151,7 @@ impl Command for Update<'_> {
 #[derive(Debug, Clone, Default)]
 pub struct CreatePlaceholders {
     /// The placeholders to create.
-    pub placeholders: Vec<PlaceholderFile>, // FIXME: placeholder should be mutable
+    pub placeholders: Vec<PlaceholderFile>,
     /// The total amount of placeholders that are a child of the current directory.
     pub total: u64,
 }
@@ -203,7 +203,7 @@ impl Command for CreatePlaceholders {
     }
 }
 
-impl<'a> Fallible for CreatePlaceholders {
+impl Fallible for CreatePlaceholders {
     fn fail(
         connection_key: RawConnectionKey,
         transfer_key: RawTransferKey,

--- a/src/filter/ticket.rs
+++ b/src/filter/ticket.rs
@@ -82,7 +82,7 @@ impl FetchPlaceholders {
     /// The value returned is the final [Usn][crate::Usn] (and if they succeeded) after each placeholder is created.
     pub fn pass_with_placeholder(
         &self,
-        placeholders: Vec<PlaceholderFile>,
+        placeholders: &mut [PlaceholderFile],
     ) -> core::Result<Vec<core::Result<Usn>>> {
         command::CreatePlaceholders {
             total: placeholders.len() as _,

--- a/src/filter/ticket.rs
+++ b/src/filter/ticket.rs
@@ -80,13 +80,13 @@ impl FetchPlaceholders {
     /// Creates a list of placeholder files/directorys on the file system.
     ///
     /// The value returned is the final [Usn][crate::Usn] (and if they succeeded) after each placeholder is created.
-    pub fn pass_with_placeholder<'a>(
+    pub fn pass_with_placeholder(
         &self,
-        placeholders: &'a [PlaceholderFile<'a>],
+        placeholders: Vec<PlaceholderFile>,
     ) -> core::Result<Vec<core::Result<Usn>>> {
         command::CreatePlaceholders {
-            placeholders,
             total: placeholders.len() as _,
+            placeholders,
         }
         .execute(self.connection_key, self.transfer_key)
     }

--- a/src/placeholder.rs
+++ b/src/placeholder.rs
@@ -265,11 +265,7 @@ pub struct UpdateOptions<'a>(Update<'a>);
 impl<'a> UpdateOptions<'a> {
     /// Create a new [UpdateOptions][crate::UpdateOptions].
     pub fn new() -> Self {
-        Self(Update {
-            mark_sync: false,
-            metadata: None,
-            blob: None,
-        })
+        Self::default()
     }
 
     /// Marks the placeholder as synced.
@@ -309,7 +305,11 @@ impl<'a> UpdateOptions<'a> {
 
 impl<'a> Default for UpdateOptions<'a> {
     fn default() -> Self {
-        Self::new()
+        Self(Update {
+            mark_sync: false,
+            metadata: None,
+            blob: None,
+        })
     }
 }
 

--- a/src/placeholder.rs
+++ b/src/placeholder.rs
@@ -259,13 +259,17 @@ impl Seek for Placeholder {
 }
 
 /// Various properties to update a placeholder in batch.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub struct UpdateOptions<'a>(Update<'a>);
 
 impl<'a> UpdateOptions<'a> {
     /// Create a new [UpdateOptions][crate::UpdateOptions].
     pub fn new() -> Self {
-        Self::default()
+        Self(Update {
+            mark_sync: false,
+            metadata: None,
+            blob: None,
+        })
     }
 
     /// Marks the placeholder as synced.

--- a/src/placeholder.rs
+++ b/src/placeholder.rs
@@ -307,6 +307,12 @@ impl<'a> UpdateOptions<'a> {
     }
 }
 
+impl<'a> Default for UpdateOptions<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // Equivalent to https://docs.microsoft.com/en-us/windows/win32/api/propvarutil/nf-propvarutil-initpropvariantfromuint32
 // windows-rs doesn't provide bindings to inlined functions
 #[allow(non_snake_case)]

--- a/src/placeholder_file.rs
+++ b/src/placeholder_file.rs
@@ -23,7 +23,7 @@ use crate::usn::Usn;
 #[derive(Debug, Clone)]
 pub struct PlaceholderFile(CF_PLACEHOLDER_CREATE_INFO);
 
-impl<'a> PlaceholderFile {
+impl PlaceholderFile {
     /// Creates a new [PlaceholderFile][crate::PlaceholderFile].
     pub fn new(relative_path: impl AsRef<Path>) -> Self {
         Self(CF_PLACEHOLDER_CREATE_INFO {

--- a/src/placeholder_file.rs
+++ b/src/placeholder_file.rs
@@ -1,5 +1,4 @@
-use ::core::slice;
-use std::{fs, os::windows::prelude::MetadataExt, path::Path, ptr};
+use std::{fs, os::windows::prelude::MetadataExt, path::Path, ptr, slice};
 
 use widestring::U16CString;
 use windows::{
@@ -20,7 +19,7 @@ use crate::usn::Usn;
 // TODO: this struct could probably have a better name to represent files/dirs
 /// A builder for creating new placeholder files/directories.
 #[repr(C)]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PlaceholderFile(CF_PLACEHOLDER_CREATE_INFO);
 
 impl PlaceholderFile {


### PR DESCRIPTION
This PR is refactors `PlaceholderFile` to own user data instead of borrowing it. It will make `PlaceholderFile` more easy to use.