### PR TITLE
refactor: update dependencies and examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 widestring = "1.1.0"
-windows = { version = "0.52.0", features = [
+windows = { version = "0.61.3", features = [
   "Win32_Foundation",
   "Win32_Storage_CloudFilters",
   "Win32_System_SystemServices",
@@ -29,6 +29,7 @@ windows = { version = "0.52.0", features = [
   "Win32_System_Ioctl",
   "Win32_Security",
   "Win32_System_Variant",
+  "Storage_Search",
 ] }
 globset = { version = "0.4.14", optional = true }
 
@@ -36,6 +37,5 @@ globset = { version = "0.4.14", optional = true }
 # Enable globs in the `info::FetchPlaceholders` struct.
 globs = ["globset"]
 
-# TODO: temporarily ignored
 [workspace]
-members = ["examples/sftp"]
+members = ["examples/*"]

--- a/examples/cloud-mirror/Cargo.toml
+++ b/examples/cloud-mirror/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 wincs = { path = "../../" }
-widestring = "0.5.1"
+widestring = "1.2.0"
 ctrlc = "3.2.1"
 wfd = "0.1.7"
-rkyv = "0.7.30"
+rkyv = "0.8.11"

--- a/examples/cloud-mirror/src/main.rs
+++ b/examples/cloud-mirror/src/main.rs
@@ -150,7 +150,7 @@ fn create_placeholders(server_path: &Path, client_path: &Path, relative_path: &P
                 .has_no_children()
                 .mark_sync()
                 .blob(blob.to_vec())
-                .create::<&PathBuf>(&client_path.join(relative_path))
+                .create(&client_path.join(relative_path))
                 .unwrap();
         }
 

--- a/examples/sftp/src/main.rs
+++ b/examples/sftp/src/main.rs
@@ -15,10 +15,8 @@ use thiserror::Error;
 use widestring::{u16str, U16String};
 use wincs::{
     ext::{ConvertOptions, FileExt},
-    filter::{info, ticket, SyncFilter},
-    placeholder_file::{Metadata, PlaceholderFile},
-    request::Request,
-    CloudErrorKind, PopulationType, Registration, SecurityId, SyncRootIdBuilder,
+    info, ticket, CloudErrorKind, Metadata, PlaceholderFile, PopulationType, Registration, Request,
+    SecurityId, SyncFilter, SyncRootIdBuilder,
 };
 
 // max should be 65536, this is done both in term-scp and sshfs because it's the
@@ -52,7 +50,8 @@ fn main() {
 
     let sync_root_id = SyncRootIdBuilder::new(U16String::from_str(PROVIDER_NAME))
         .user_security_id(SecurityId::current_user().unwrap())
-        .build();
+        .build()
+        .unwrap();
 
     let client_path = get_client_path();
     if !sync_root_id.is_registered().unwrap() {

--- a/src/command/commands.rs
+++ b/src/command/commands.rs
@@ -34,7 +34,7 @@ impl Command for Read<'_> {
     const OPERATION: CF_OPERATION_TYPE = CloudFilters::CF_OPERATION_TYPE_RETRIEVE_DATA;
 
     type Result = u64;
-    type Field = CF_OPERATION_PARAMETERS_0_5;
+    type Field = CF_OPERATION_PARAMETERS_0_1;
 
     unsafe fn result(info: CF_OPERATION_PARAMETERS_0) -> Self::Result {
         info.RetrieveData.ReturnedLength as u64
@@ -42,7 +42,7 @@ impl Command for Read<'_> {
 
     fn build(&self) -> CF_OPERATION_PARAMETERS_0 {
         CF_OPERATION_PARAMETERS_0 {
-            RetrieveData: CF_OPERATION_PARAMETERS_0_5 {
+            RetrieveData: CF_OPERATION_PARAMETERS_0_1 {
                 Flags: CloudFilters::CF_OPERATION_RETRIEVE_DATA_FLAG_NONE,
                 Buffer: self.buffer.as_ptr() as *mut _,
                 Offset: self.position as i64,
@@ -66,13 +66,13 @@ impl Command for Write<'_> {
     const OPERATION: CF_OPERATION_TYPE = CloudFilters::CF_OPERATION_TYPE_TRANSFER_DATA;
 
     type Result = ();
-    type Field = CF_OPERATION_PARAMETERS_0_6;
+    type Field = CF_OPERATION_PARAMETERS_0_0;
 
     unsafe fn result(_info: CF_OPERATION_PARAMETERS_0) -> Self::Result {}
 
     fn build(&self) -> CF_OPERATION_PARAMETERS_0 {
         CF_OPERATION_PARAMETERS_0 {
-            TransferData: CF_OPERATION_PARAMETERS_0_6 {
+            TransferData: CF_OPERATION_PARAMETERS_0_0 {
                 // TODO: add flag for disable_on_demand_population
                 Flags: CloudFilters::CF_OPERATION_TRANSFER_DATA_FLAG_NONE,
                 CompletionStatus: Foundation::STATUS_SUCCESS,
@@ -92,7 +92,7 @@ impl Fallible for Write<'_> {
     ) -> core::Result<Self::Result> {
         execute::<Self>(
             CF_OPERATION_PARAMETERS_0 {
-                TransferData: CF_OPERATION_PARAMETERS_0_6 {
+                TransferData: CF_OPERATION_PARAMETERS_0_0 {
                     Flags: CloudFilters::CF_OPERATION_TRANSFER_DATA_FLAG_NONE,
                     CompletionStatus: error_kind.into(),
                     // TODO: SAME HERE AS BELOW?
@@ -123,13 +123,13 @@ impl Command for Update<'_> {
     const OPERATION: CF_OPERATION_TYPE = CloudFilters::CF_OPERATION_TYPE_RESTART_HYDRATION;
 
     type Result = ();
-    type Field = CF_OPERATION_PARAMETERS_0_4;
+    type Field = CF_OPERATION_PARAMETERS_0_3;
 
     unsafe fn result(_info: CF_OPERATION_PARAMETERS_0) -> Self::Result {}
 
     fn build(&self) -> CF_OPERATION_PARAMETERS_0 {
         CF_OPERATION_PARAMETERS_0 {
-            RestartHydration: CF_OPERATION_PARAMETERS_0_4 {
+            RestartHydration: CF_OPERATION_PARAMETERS_0_3 {
                 Flags: if self.mark_sync {
                     CloudFilters::CF_OPERATION_RESTART_HYDRATION_FLAG_MARK_IN_SYNC
                 } else {
@@ -160,7 +160,7 @@ impl Command for CreatePlaceholders<'_> {
     const OPERATION: CF_OPERATION_TYPE = CloudFilters::CF_OPERATION_TYPE_TRANSFER_PLACEHOLDERS;
 
     type Result = Vec<core::Result<Usn>>;
-    type Field = CF_OPERATION_PARAMETERS_0_7;
+    type Field = CF_OPERATION_PARAMETERS_0_4;
 
     unsafe fn result(info: CF_OPERATION_PARAMETERS_0) -> Self::Result {
         // iterate over the placeholders and return, in a new vector, whether or
@@ -185,7 +185,7 @@ impl Command for CreatePlaceholders<'_> {
 
     fn build(&self) -> CF_OPERATION_PARAMETERS_0 {
         CF_OPERATION_PARAMETERS_0 {
-            TransferPlaceholders: CF_OPERATION_PARAMETERS_0_7 {
+            TransferPlaceholders: CF_OPERATION_PARAMETERS_0_4 {
                 // TODO: this flag tells the system there are no more placeholders in this directory (when that can be untrue)
                 //       in the future, implement streaming
                 Flags: CloudFilters::CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAG_DISABLE_ON_DEMAND_POPULATION,
@@ -211,7 +211,7 @@ impl Fallible for CreatePlaceholders<'_> {
     ) -> core::Result<Self::Result> {
         execute::<Self>(
             CF_OPERATION_PARAMETERS_0 {
-                TransferPlaceholders: CF_OPERATION_PARAMETERS_0_7 {
+                TransferPlaceholders: CF_OPERATION_PARAMETERS_0_4 {
                     Flags: CloudFilters::CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAG_NONE,
                     CompletionStatus: error_kind.into(),
                     PlaceholderTotalCount: 0,
@@ -238,13 +238,13 @@ impl Command for Validate {
     const OPERATION: CF_OPERATION_TYPE = CloudFilters::CF_OPERATION_TYPE_ACK_DATA;
 
     type Result = ();
-    type Field = CF_OPERATION_PARAMETERS_0_0;
+    type Field = CF_OPERATION_PARAMETERS_0_2;
 
     unsafe fn result(_info: CF_OPERATION_PARAMETERS_0) -> Self::Result {}
 
     fn build(&self) -> CF_OPERATION_PARAMETERS_0 {
         CF_OPERATION_PARAMETERS_0 {
-            AckData: CF_OPERATION_PARAMETERS_0_0 {
+            AckData: CF_OPERATION_PARAMETERS_0_2 {
                 Flags: CloudFilters::CF_OPERATION_ACK_DATA_FLAG_NONE,
                 CompletionStatus: Foundation::STATUS_SUCCESS,
                 Offset: self.range.start as i64,
@@ -262,7 +262,7 @@ impl Fallible for Validate {
     ) -> core::Result<Self::Result> {
         execute::<Self>(
             CF_OPERATION_PARAMETERS_0 {
-                AckData: CF_OPERATION_PARAMETERS_0_0 {
+                AckData: CF_OPERATION_PARAMETERS_0_2 {
                     Flags: CloudFilters::CF_OPERATION_ACK_DATA_FLAG_NONE,
                     CompletionStatus: error_kind.into(),
                     Offset: 0,
@@ -286,13 +286,13 @@ impl Command for Dehydrate<'_> {
     const OPERATION: CF_OPERATION_TYPE = CloudFilters::CF_OPERATION_TYPE_ACK_DEHYDRATE;
 
     type Result = ();
-    type Field = CF_OPERATION_PARAMETERS_0_1;
+    type Field = CF_OPERATION_PARAMETERS_0_5;
 
     unsafe fn result(_info: CF_OPERATION_PARAMETERS_0) -> Self::Result {}
 
     fn build(&self) -> CF_OPERATION_PARAMETERS_0 {
         CF_OPERATION_PARAMETERS_0 {
-            AckDehydrate: CF_OPERATION_PARAMETERS_0_1 {
+            AckDehydrate: CF_OPERATION_PARAMETERS_0_5 {
                 Flags: CloudFilters::CF_OPERATION_ACK_DEHYDRATE_FLAG_NONE,
                 CompletionStatus: Foundation::STATUS_SUCCESS,
                 FileIdentity: self
@@ -312,7 +312,7 @@ impl Fallible for Dehydrate<'_> {
     ) -> core::Result<Self::Result> {
         execute::<Self>(
             CF_OPERATION_PARAMETERS_0 {
-                AckDehydrate: CF_OPERATION_PARAMETERS_0_1 {
+                AckDehydrate: CF_OPERATION_PARAMETERS_0_5 {
                     Flags: CloudFilters::CF_OPERATION_ACK_DEHYDRATE_FLAG_NONE,
                     CompletionStatus: error_kind.into(),
                     FileIdentity: ptr::null(),
@@ -333,13 +333,13 @@ impl Command for Delete {
     const OPERATION: CF_OPERATION_TYPE = CloudFilters::CF_OPERATION_TYPE_ACK_DELETE;
 
     type Result = ();
-    type Field = CF_OPERATION_PARAMETERS_0_2;
+    type Field = CF_OPERATION_PARAMETERS_0_7;
 
     unsafe fn result(_info: CF_OPERATION_PARAMETERS_0) -> Self::Result {}
 
     fn build(&self) -> CF_OPERATION_PARAMETERS_0 {
         CF_OPERATION_PARAMETERS_0 {
-            AckDelete: CF_OPERATION_PARAMETERS_0_2 {
+            AckDelete: CF_OPERATION_PARAMETERS_0_7 {
                 Flags: CloudFilters::CF_OPERATION_ACK_DELETE_FLAG_NONE,
                 CompletionStatus: Foundation::STATUS_SUCCESS,
             },
@@ -355,7 +355,7 @@ impl Fallible for Delete {
     ) -> core::Result<Self::Result> {
         execute::<Self>(
             CF_OPERATION_PARAMETERS_0 {
-                AckDelete: CF_OPERATION_PARAMETERS_0_2 {
+                AckDelete: CF_OPERATION_PARAMETERS_0_7 {
                     Flags: CloudFilters::CF_OPERATION_ACK_DELETE_FLAG_NONE,
                     CompletionStatus: error_kind.into(),
                 },
@@ -374,13 +374,13 @@ impl Command for Rename {
     const OPERATION: CF_OPERATION_TYPE = CloudFilters::CF_OPERATION_TYPE_ACK_RENAME;
 
     type Result = ();
-    type Field = CF_OPERATION_PARAMETERS_0_3;
+    type Field = CF_OPERATION_PARAMETERS_0_6;
 
     unsafe fn result(_info: CF_OPERATION_PARAMETERS_0) -> Self::Result {}
 
     fn build(&self) -> CF_OPERATION_PARAMETERS_0 {
         CF_OPERATION_PARAMETERS_0 {
-            AckRename: CF_OPERATION_PARAMETERS_0_3 {
+            AckRename: CF_OPERATION_PARAMETERS_0_6 {
                 Flags: CloudFilters::CF_OPERATION_ACK_RENAME_FLAG_NONE,
                 CompletionStatus: Foundation::STATUS_SUCCESS,
             },
@@ -396,7 +396,7 @@ impl Fallible for Rename {
     ) -> core::Result<Self::Result> {
         execute::<Self>(
             CF_OPERATION_PARAMETERS_0 {
-                AckRename: CF_OPERATION_PARAMETERS_0_3 {
+                AckRename: CF_OPERATION_PARAMETERS_0_6 {
                     Flags: CloudFilters::CF_OPERATION_ACK_RENAME_FLAG_NONE,
                     CompletionStatus: error_kind.into(),
                 },

--- a/src/filter/info.rs
+++ b/src/filter/info.rs
@@ -11,7 +11,7 @@ use windows::Win32::Storage::CloudFilters::{
 
 /// Information for the [SyncFilter::fetch_data][crate::SyncFilter::fetch_data] callback.
 #[derive(Debug, Clone, Copy)]
-pub struct FetchData(pub(crate) CF_CALLBACK_PARAMETERS_0_6);
+pub struct FetchData(pub(crate) CF_CALLBACK_PARAMETERS_0_1);
 
 impl FetchData {
     /// Whether or not the callback was called from an interrupted hydration.
@@ -102,7 +102,7 @@ struct CancelFetchDataDebug {
 
 /// Information for the [SyncFilter::validate_data][crate::SyncFilter::validate_data] callback.
 #[derive(Debug, Clone, Copy)]
-pub struct ValidateData(pub(crate) CF_CALLBACK_PARAMETERS_0_11);
+pub struct ValidateData(pub(crate) CF_CALLBACK_PARAMETERS_0_2);
 
 impl ValidateData {
     /// Whether or not the callback failed as a result of the 60 second timeout.
@@ -120,7 +120,7 @@ impl ValidateData {
 /// Information for the [SyncFilter::fetch_placeholders][crate::SyncFilter::fetch_placeholders]
 /// callback.
 #[derive(Debug)]
-pub struct FetchPlaceholders(pub(crate) CF_CALLBACK_PARAMETERS_0_7);
+pub struct FetchPlaceholders(pub(crate) CF_CALLBACK_PARAMETERS_0_3);
 
 impl FetchPlaceholders {
     /// A glob pattern specifying the files that should be fetched.
@@ -180,7 +180,7 @@ struct CancelFetchPlaceholdersDebug {
 
 /// Information for the [SyncFilter::opened][crate::SyncFilter::opened] callback.
 #[derive(Debug, Clone, Copy)]
-pub struct Opened(pub(crate) CF_CALLBACK_PARAMETERS_0_8);
+pub struct Opened(pub(crate) CF_CALLBACK_PARAMETERS_0_4);
 
 impl Opened {
     /// The placeholder metadata is corrupt.
@@ -197,7 +197,7 @@ impl Opened {
 
 /// Information for the [SyncFilter::closed][crate::SyncFilter::closed] callback.
 #[derive(Debug, Clone, Copy)]
-pub struct Closed(pub(crate) CF_CALLBACK_PARAMETERS_0_1);
+pub struct Closed(pub(crate) CF_CALLBACK_PARAMETERS_0_5);
 
 impl Closed {
     /// Whether or not the placeholder was deleted as a result of the close.
@@ -208,7 +208,7 @@ impl Closed {
 
 /// Information for the [SyncFilter::dehydrate][crate::SyncFilter::dehydrate] callback.
 #[derive(Debug, Clone, Copy)]
-pub struct Dehydrate(pub(crate) CF_CALLBACK_PARAMETERS_0_3);
+pub struct Dehydrate(pub(crate) CF_CALLBACK_PARAMETERS_0_6);
 
 impl Dehydrate {
     /// Whether or not the callback was called from a system background service.
@@ -224,7 +224,7 @@ impl Dehydrate {
 
 /// Information for the [SyncFilter::dehydrated][crate::SyncFilter::dehydrated] callback.
 #[derive(Debug, Clone, Copy)]
-pub struct Dehydrated(pub(crate) CF_CALLBACK_PARAMETERS_0_2);
+pub struct Dehydrated(pub(crate) CF_CALLBACK_PARAMETERS_0_7);
 
 impl Dehydrated {
     /// Whether or not the callback was called from a system background service.
@@ -245,7 +245,7 @@ impl Dehydrated {
 
 /// Information for the [SyncFilter::delete][crate::SyncFilter::delete] callback.
 #[derive(Debug, Clone, Copy)]
-pub struct Delete(pub(crate) CF_CALLBACK_PARAMETERS_0_5);
+pub struct Delete(pub(crate) CF_CALLBACK_PARAMETERS_0_8);
 
 impl Delete {
     /// Whether or not the placeholder being deleted is a directory.
@@ -262,7 +262,7 @@ impl Delete {
 /// Information for the [SyncFilter::deleted][crate::SyncFilter::deleted] callback.
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
-pub struct Deleted(pub(crate) CF_CALLBACK_PARAMETERS_0_4);
+pub struct Deleted(pub(crate) CF_CALLBACK_PARAMETERS_0_9);
 
 /// Information for the [SyncFilter::rename][crate::SyncFilter::rename] callback.
 #[derive(Debug)]
@@ -296,7 +296,7 @@ impl Rename {
 
 /// Information for the [SyncFilter::renamed][crate::SyncFilter::renamed] callback.
 #[derive(Debug)]
-pub struct Renamed(pub(crate) CF_CALLBACK_PARAMETERS_0_9);
+pub struct Renamed(pub(crate) CF_CALLBACK_PARAMETERS_0_11);
 
 impl Renamed {
     /// The full path the placeholder has been moved from.

--- a/src/placeholder.rs
+++ b/src/placeholder.rs
@@ -4,11 +4,11 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
 };
-
 use widestring::U16CString;
 use windows::{
     core::{self, GUID, PCWSTR},
     Win32::{
+        Foundation::PROPERTYKEY,
         Storage::{
             CloudFilters::{self, CfReportProviderProgress, CF_CONNECTION_KEY},
             EnhancedStorage,
@@ -22,7 +22,7 @@ use windows::{
         },
         UI::Shell::{
             self, IShellItem2,
-            PropertiesSystem::{self, IPropertyStore, PROPERTYKEY},
+            PropertiesSystem::{self, IPropertyStore},
             SHChangeNotify, SHCreateItemFromParsingName,
         },
     },

--- a/src/placeholder_file.rs
+++ b/src/placeholder_file.rs
@@ -120,10 +120,10 @@ impl PlaceholderFile {
     ///
     /// If you need to create placeholders from the [SyncFilter::fetch_placeholders][crate::SyncFilter::fetch_placeholders] callback, do not use this method. Instead, use
     /// [FetchPlaceholders::pass_with_placeholders][crate::ticket::FetchPlaceholders::pass_with_placeholders].
-    pub fn create<P: AsRef<Path>>(self, parent: impl AsRef<Path>) -> core::Result<Usn> {
+    pub fn create(self, parent: &Path) -> core::Result<Usn> {
         unsafe {
             CfCreatePlaceholders(
-                PCWSTR::from_raw(U16CString::from_os_str(parent.as_ref()).unwrap().as_ptr()),
+                PCWSTR::from_raw(U16CString::from_os_str(parent).unwrap().as_ptr()),
                 &mut [self.0],
                 CloudFilters::CF_CREATE_FLAG_NONE,
                 None,

--- a/src/root/sync_root.rs
+++ b/src/root/sync_root.rs
@@ -1,11 +1,11 @@
-use std::{mem::MaybeUninit, path::Path, ptr};
+use std::{ffi, mem::MaybeUninit, path::Path, ptr};
 
 use widestring::{U16CString, U16Str, U16String};
 use windows::{
     core::{self, HSTRING, PWSTR},
     Storage::Provider::StorageProviderSyncRootManager,
     Win32::{
-        Foundation::{self, GetLastError, LocalFree, HANDLE, HLOCAL},
+        Foundation::{self, GetLastError, LocalFree, HANDLE, HLOCAL, SUCCESS},
         Security::{self, Authorization::ConvertSidToStringSidW, GetTokenInformation, TOKEN_USER},
         Storage::CloudFilters,
     },
@@ -81,7 +81,7 @@ impl SyncRootIdBuilder {
                 self.account_name.as_slice(),
             ]
             .join(&SyncRootId::SEPARATOR),
-        )?))
+        )))
     }
 }
 
@@ -124,7 +124,7 @@ impl SyncRootId {
 
     /// A reference to the [SyncRootId][crate::SyncRootId] as a 16 bit string.
     pub fn as_u16str(&self) -> &U16Str {
-        U16Str::from_slice(self.0.as_wide())
+        U16Str::from_slice(&self.0)
     }
 
     /// A reference to the [SyncRootId][crate::SyncRootId] as an [HSTRING][windows::core::HSTRING] (its inner value).
@@ -136,25 +136,27 @@ impl SyncRootId {
     ///
     /// The order goes as follows:
     /// `(provider-id, security-id, account-name)`
-    // TODO: This doesn't work properly, it forgets to include the account name
-    pub fn to_components(&self) -> (&U16Str, &U16Str, &U16Str) {
-        let mut components = Vec::with_capacity(3);
-        let mut bytes = self.0.as_wide();
+    pub fn to_components(&self) -> core::Result<(&U16Str, &U16Str, &U16Str)> {
+        let bytes = &self.0;
 
-        for index in 0..2 {
-            match bytes.iter().position(|&byte| byte == Self::SEPARATOR) {
-                Some(position) => {
-                    components.insert(index, U16Str::from_slice(bytes));
-                    bytes = &bytes[(position + 1)..];
-                }
-                None => {
-                    // TODO: return a result instead of panic
-                    panic!("malformed sync root id, got {:?}", components)
-                }
-            }
-        }
+        // Find the first separator
+        let first_sep = bytes
+            .iter()
+            .position(|&byte| byte == Self::SEPARATOR)
+            .ok_or(Foundation::ERROR_INVALID_DATA)?;
 
-        (components[0], components[1], components[2])
+        // Find the second separator after the first one
+        let second_sep = bytes[(first_sep + 1)..]
+            .iter()
+            .position(|&byte| byte == Self::SEPARATOR)
+            .map(|pos| pos + first_sep + 1)
+            .ok_or(Foundation::ERROR_INVALID_DATA)?;
+
+        Ok((
+            U16Str::from_slice(&bytes[..first_sep]),
+            U16Str::from_slice(&bytes[(first_sep + 1)..second_sep]),
+            U16Str::from_slice(&bytes[(second_sep + 1)..]),
+        ))
     }
 }
 
@@ -164,7 +166,7 @@ pub struct SecurityId(U16String);
 
 impl SecurityId {
     // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentthreadeffectivetoken
-    const CURRENT_THREAD_EFFECTIVE_TOKEN: HANDLE = HANDLE(-6);
+    const CURRENT_THREAD_EFFECTIVE_TOKEN: HANDLE = HANDLE(-6i32 as *mut ffi::c_void);
 
     /// Creates a new [SecurityId][crate::SecurityId] without any assertions.
     pub fn new_unchecked(id: U16String) -> Self {
@@ -185,9 +187,7 @@ impl SecurityId {
                 &mut token_size,
             )
             .is_err()
-                && GetLastError().is_err_and(|err| {
-                    err.code() == Foundation::ERROR_INSUFFICIENT_BUFFER.to_hresult()
-                })
+                && GetLastError() == Foundation::ERROR_INSUFFICIENT_BUFFER
             {
                 GetTokenInformation(
                     Self::CURRENT_THREAD_EFFECTIVE_TOKEN,
@@ -203,7 +203,14 @@ impl SecurityId {
             ConvertSidToStringSidW(token.User.Sid, &mut sid as *mut _)?;
 
             let string_sid = U16CString::from_ptr_str(sid.0).into_ustring();
-            LocalFree(HLOCAL(sid.0 as *mut _))?;
+
+            // Fix the LocalFree call - we should handle the result properly
+            if !LocalFree(Some(HLOCAL(sid.0 as *mut _))).0.is_null() {
+                let last_error = GetLastError();
+                if last_error.0 != SUCCESS {
+                    return Err(last_error.into());
+                }
+            }
 
             Ok(SecurityId::new_unchecked(string_sid))
         }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -8,7 +8,7 @@ where
 {
     /// Converts a 16-bit buffer to a Windows reference-counted [HSTRING][windows::core::HSTRING].
     fn to_hstring(&self) -> core::Result<HSTRING> {
-        HSTRING::from_wide(self.as_ref())
+        Ok(HSTRING::from_wide(self.as_ref()))
     }
 }
 


### PR DESCRIPTION
## Description

This PR updates the Windows crate and aligns examples with the latest APIs. The cloud-mirror example has been fully tested, while the sftp example now compiles but remains untested.

## Changes
- Bump Windows dependency to the latest version  
- Fix sync root ID parsing
- Refactor and update dependencies of cloud-mirror example.
- Fix sftp example compilation issues