### PR TITLE
allow index/resource id to be negative

### DIFF
--- a/src/root/register.rs
+++ b/src/root/register.rs
@@ -130,7 +130,7 @@ impl<'a> Registration<'a> {
     // TODO: this field is required
     // https://docs.microsoft.com/en-us/windows/win32/menurc/icon-resource
 
-    pub fn icon(mut self, mut path: U16String, index: u16) -> Self {
+    pub fn icon(mut self, mut path: U16String, index: i16) -> Self {
         path.push_str(format!(",{index}"));
         self.icon = path;
         self


### PR DESCRIPTION
The underlying API doc specifies that positive values are treated as the index of the icon in the file, while negative numbers are treated as a resource identifier. An index might change if icons are added/removed, but the resource identifier is stable.

https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-extracticona https://stackoverflow.com/a/44442640
https://devblogs.microsoft.com/oldnewthing/20100505-00/?p=14153